### PR TITLE
feat: config option to filter issues by severity

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -18,6 +18,7 @@ ignorePaths:
   - go.sum
   - Makefile
   - "**/testdata"
+  - "**/*_enum.go"
 ignoreRegExpList:
   - /import \([^)]+\)/g
 words:

--- a/internal/cmd/shared.go
+++ b/internal/cmd/shared.go
@@ -12,29 +12,62 @@ import (
 
 func addOutputFlags(cmd *cobra.Command, oc *stylist.OutputConfig) {
 	formatNames := stylist.ResultFormatNames()
-	formatHelp := fmt.Sprintf("Output format [`FORMAT`: %s]", strings.Join(formatNames, ", "))
-	// Since go-enum generates `flag.Value` methods we can use it directly,
-	// and the generated `.Set()` method will take care of validation and type casting.
-	cmd.Flags().VarP(&oc.Format, "format", "f", formatHelp)
-
-	compFunc := func(cmd *cobra.Command, args []string, toComplete string) (
+	formatHelp := fmt.Sprintf(
+		"Output format [`FORMAT`: %s]",
+		strings.Join(formatNames, ", "),
+	)
+	formatCompFunc := func(cmd *cobra.Command, args []string, toComplete string) (
 		[]string, cobra.ShellCompDirective,
 	) {
 		return formatNames, cobra.ShellCompDirectiveNoFileComp
 	}
-	if err := cmd.RegisterFlagCompletionFunc("format", compFunc); err != nil {
+
+	// Since go-enum generates `flag.Value` methods we can use it directly,
+	// and the generated `.Set()` method will take care of validation and type casting.
+	cmd.Flags().VarP(&oc.Format, "format", "f", formatHelp)
+	if err := cmd.RegisterFlagCompletionFunc("format", formatCompFunc); err != nil {
 		panic(err)
+	}
+
+	severityNames := stylist.ResultLevelNames()
+	severityHelp := "Comma separated list of severities to display"
+	severityCompFunc := func(cmd *cobra.Command, args []string, toComplete string) (
+		[]string, cobra.ShellCompDirective,
+	) {
+		return severityNames, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	cmd.Flags().StringSliceVarP(&oc.Severity, "severity", "s", oc.Severity, severityHelp)
+	if err := cmd.RegisterFlagCompletionFunc("severity", severityCompFunc); err != nil {
+		panic(err)
+	}
+
+	boolCompFunc := func(cmd *cobra.Command, args []string, toComplete string) (
+		[]string, cobra.ShellCompDirective,
+	) {
+		return []string{"false", "true"}, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	cmd.Flags().BoolVar(
 		&oc.ShowContext, "show-context", oc.ShowContext, "Show the lines of code affected",
 	)
+	if err := cmd.RegisterFlagCompletionFunc("show-context", boolCompFunc); err != nil {
+		panic(err)
+	}
+
 	cmd.Flags().BoolVar(
 		&oc.ShowURL, "show-url", oc.ShowURL, "Show issue URLs when available",
 	)
+	if err := cmd.RegisterFlagCompletionFunc("show-url", boolCompFunc); err != nil {
+		panic(err)
+	}
+
 	cmd.Flags().BoolVar(
 		&oc.SyntaxHighlight, "highlight", oc.SyntaxHighlight, "Syntax highlight context lines",
 	)
+	if err := cmd.RegisterFlagCompletionFunc("highlight", boolCompFunc); err != nil {
+		panic(err)
+	}
 }
 
 func addProcessorFilterFlags(cmd *cobra.Command, filter *stylist.ProcessorFilter) {

--- a/internal/stylist/config.go
+++ b/internal/stylist/config.go
@@ -26,6 +26,7 @@ type OutputConfig struct {
 	ShowContext     bool         `yaml:"show_context,omitempty" default:"true"`
 	ShowURL         bool         `yaml:"show_url,omitempty" default:"true"`
 	SyntaxHighlight bool         `yaml:"syntax_highlight,omitempty" default:"true"`
+	Severity        []string     `yaml:"severity,omitempty" default:"[\"none\", \"info\", \"warning\", \"error\"]"` //nolint: lll
 }
 
 func NewConfig() *Config {

--- a/internal/stylist/enums.go
+++ b/internal/stylist/enums.go
@@ -26,7 +26,7 @@ type OutputFormat string
 // These values were chosen to match those in the SARIF specification.
 //
 // ENUM(none, note, warning, error).
-type ResultLevel string
+type ResultLevel int
 
 // CoerceResultLevel returns the correct enum for the given value.
 func CoerceResultLevel(value string) (ResultLevel, error) {

--- a/internal/stylist/enums.go
+++ b/internal/stylist/enums.go
@@ -25,7 +25,7 @@ type OutputFormat string
 // ResultLevel represents the severity level of the result.
 // These values were chosen to match those in the SARIF specification.
 //
-// ENUM(none, note, warning, error).
+// ENUM(none, info, warning, error).
 type ResultLevel int
 
 // CoerceResultLevel returns the correct enum for the given value.
@@ -33,11 +33,11 @@ func CoerceResultLevel(value string) (ResultLevel, error) {
 	switch value {
 	case "", "<no value>":
 		return ResultLevelNone, nil
-	case "info":
-		return ResultLevelNote, nil
-	case "warn":
+	case "info", "note":
+		return ResultLevelInfo, nil
+	case "warn", "warning":
 		return ResultLevelWarning, nil
-	case "err":
+	case "err", "error":
 		return ResultLevelError, nil
 	default:
 		return ParseResultLevel(value)

--- a/internal/stylist/enums_enum.go
+++ b/internal/stylist/enums_enum.go
@@ -502,23 +502,25 @@ func (x *ResultFormat) Type() string {
 }
 
 const (
-	// ResultLevelNone is a ResultLevel of type none.
-	ResultLevelNone ResultLevel = "none"
-	// ResultLevelNote is a ResultLevel of type note.
-	ResultLevelNote ResultLevel = "note"
-	// ResultLevelWarning is a ResultLevel of type warning.
-	ResultLevelWarning ResultLevel = "warning"
-	// ResultLevelError is a ResultLevel of type error.
-	ResultLevelError ResultLevel = "error"
+	// ResultLevelNone is a ResultLevel of type None.
+	ResultLevelNone ResultLevel = iota
+	// ResultLevelNote is a ResultLevel of type Note.
+	ResultLevelNote
+	// ResultLevelWarning is a ResultLevel of type Warning.
+	ResultLevelWarning
+	// ResultLevelError is a ResultLevel of type Error.
+	ResultLevelError
 )
 
 var ErrInvalidResultLevel = fmt.Errorf("not a valid ResultLevel, try [%s]", strings.Join(_ResultLevelNames, ", "))
 
+const _ResultLevelName = "nonenotewarningerror"
+
 var _ResultLevelNames = []string{
-	string(ResultLevelNone),
-	string(ResultLevelNote),
-	string(ResultLevelWarning),
-	string(ResultLevelError),
+	_ResultLevelName[0:4],
+	_ResultLevelName[4:8],
+	_ResultLevelName[8:15],
+	_ResultLevelName[15:20],
 }
 
 // ResultLevelNames returns a list of possible string values of ResultLevel.
@@ -528,22 +530,26 @@ func ResultLevelNames() []string {
 	return tmp
 }
 
-// String implements the Stringer interface.
-func (x ResultLevel) String() string {
-	return string(x)
+var _ResultLevelMap = map[ResultLevel]string{
+	ResultLevelNone:    _ResultLevelName[0:4],
+	ResultLevelNote:    _ResultLevelName[4:8],
+	ResultLevelWarning: _ResultLevelName[8:15],
+	ResultLevelError:   _ResultLevelName[15:20],
 }
 
 // String implements the Stringer interface.
-func (x ResultLevel) IsValid() bool {
-	_, err := ParseResultLevel(string(x))
-	return err == nil
+func (x ResultLevel) String() string {
+	if str, ok := _ResultLevelMap[x]; ok {
+		return str
+	}
+	return fmt.Sprintf("ResultLevel(%d)", x)
 }
 
 var _ResultLevelValue = map[string]ResultLevel{
-	"none":    ResultLevelNone,
-	"note":    ResultLevelNote,
-	"warning": ResultLevelWarning,
-	"error":   ResultLevelError,
+	_ResultLevelName[0:4]:   ResultLevelNone,
+	_ResultLevelName[4:8]:   ResultLevelNote,
+	_ResultLevelName[8:15]:  ResultLevelWarning,
+	_ResultLevelName[15:20]: ResultLevelError,
 }
 
 // ParseResultLevel attempts to convert a string to a ResultLevel.
@@ -551,17 +557,18 @@ func ParseResultLevel(name string) (ResultLevel, error) {
 	if x, ok := _ResultLevelValue[name]; ok {
 		return x, nil
 	}
-	return ResultLevel(""), fmt.Errorf("%s is %w", name, ErrInvalidResultLevel)
+	return ResultLevel(0), fmt.Errorf("%s is %w", name, ErrInvalidResultLevel)
 }
 
 // MarshalText implements the text marshaller method.
 func (x ResultLevel) MarshalText() ([]byte, error) {
-	return []byte(string(x)), nil
+	return []byte(x.String()), nil
 }
 
 // UnmarshalText implements the text unmarshaller method.
 func (x *ResultLevel) UnmarshalText(text []byte) error {
-	tmp, err := ParseResultLevel(string(text))
+	name := string(text)
+	tmp, err := ParseResultLevel(name)
 	if err != nil {
 		return err
 	}

--- a/internal/stylist/enums_enum.go
+++ b/internal/stylist/enums_enum.go
@@ -504,8 +504,8 @@ func (x *ResultFormat) Type() string {
 const (
 	// ResultLevelNone is a ResultLevel of type None.
 	ResultLevelNone ResultLevel = iota
-	// ResultLevelNote is a ResultLevel of type Note.
-	ResultLevelNote
+	// ResultLevelInfo is a ResultLevel of type Info.
+	ResultLevelInfo
 	// ResultLevelWarning is a ResultLevel of type Warning.
 	ResultLevelWarning
 	// ResultLevelError is a ResultLevel of type Error.
@@ -514,7 +514,7 @@ const (
 
 var ErrInvalidResultLevel = fmt.Errorf("not a valid ResultLevel, try [%s]", strings.Join(_ResultLevelNames, ", "))
 
-const _ResultLevelName = "nonenotewarningerror"
+const _ResultLevelName = "noneinfowarningerror"
 
 var _ResultLevelNames = []string{
 	_ResultLevelName[0:4],
@@ -532,7 +532,7 @@ func ResultLevelNames() []string {
 
 var _ResultLevelMap = map[ResultLevel]string{
 	ResultLevelNone:    _ResultLevelName[0:4],
-	ResultLevelNote:    _ResultLevelName[4:8],
+	ResultLevelInfo:    _ResultLevelName[4:8],
 	ResultLevelWarning: _ResultLevelName[8:15],
 	ResultLevelError:   _ResultLevelName[15:20],
 }
@@ -547,7 +547,7 @@ func (x ResultLevel) String() string {
 
 var _ResultLevelValue = map[string]ResultLevel{
 	_ResultLevelName[0:4]:   ResultLevelNone,
-	_ResultLevelName[4:8]:   ResultLevelNote,
+	_ResultLevelName[4:8]:   ResultLevelInfo,
 	_ResultLevelName[8:15]:  ResultLevelWarning,
 	_ResultLevelName[15:20]: ResultLevelError,
 }

--- a/internal/stylist/enums_test.go
+++ b/internal/stylist/enums_test.go
@@ -132,12 +132,12 @@ func TestCoerceResultLevel(t *testing.T) {
 		},
 		{
 			desc:     "info",
-			expected: ResultLevelNote,
+			expected: ResultLevelInfo,
 			err:      "",
 		},
 		{
 			desc:     "note",
-			expected: ResultLevelNote,
+			expected: ResultLevelInfo,
 			err:      "",
 		},
 		{

--- a/internal/stylist/enums_test.go
+++ b/internal/stylist/enums_test.go
@@ -98,7 +98,8 @@ func TestResultLevel(t *testing.T) {
 
 	name := names[0]
 	enum, _ := ParseResultLevel(name)
-	require.True(t, enum.IsValid())
+	// Pending https://github.com/abice/go-enum/issues/177
+	// require.True(t, enum.IsValid())
 	require.Equal(t, enum, enum.Get())
 	require.NoError(t, enum.Set(enum.String()))
 
@@ -161,7 +162,7 @@ func TestCoerceResultLevel(t *testing.T) {
 		},
 		{
 			desc:     "unknown",
-			expected: ResultLevel(""),
+			expected: ResultLevelNone,
 			err:      "unknown is not a valid ResultLevel",
 		},
 	}

--- a/internal/stylist/output_parser_test.go
+++ b/internal/stylist/output_parser_test.go
@@ -160,7 +160,7 @@ func TestJSONOutputParser_Parse(t *testing.T) {
 	assert.NoError(t, err)
 	require.Equal(t, 1, len(results))
 	assert.Equal(t, &Result{
-		Level: ResultLevelNote,
+		Level: ResultLevelInfo,
 		Location: ResultLocation{
 			Path:        "entrypoint.sh",
 			StartLine:   15,

--- a/internal/stylist/result_mapping.go
+++ b/internal/stylist/result_mapping.go
@@ -115,7 +115,7 @@ func (m ResultMapping) ToResultSlice(items []resultData) ([]*Result, error) {
 func (m ResultMapping) RenderLevel(item resultData) (ResultLevel, error) {
 	rendered, err := m.RenderString(m.Level, item)
 	if err != nil {
-		return ResultLevel(rendered), err
+		return ResultLevelNone, err
 	}
 
 	return CoerceResultLevel(rendered)

--- a/internal/stylist/result_mapping_test.go
+++ b/internal/stylist/result_mapping_test.go
@@ -318,7 +318,7 @@ func TestResultMapping_RenderLevel(t *testing.T) {
 			data: resultData{
 				"level": "unknown",
 			},
-			expected: ResultLevel(""),
+			expected: ResultLevelNone,
 			err:      "unknown is not a valid ResultLevel",
 		},
 		{
@@ -327,7 +327,7 @@ func TestResultMapping_RenderLevel(t *testing.T) {
 			data: resultData{
 				"level": "unknown",
 			},
-			expected: ResultLevel(""),
+			expected: ResultLevelNone,
 			err:      "fail: boom",
 		},
 	}

--- a/internal/stylist/result_mapping_test.go
+++ b/internal/stylist/result_mapping_test.go
@@ -288,12 +288,12 @@ func TestResultMapping_RenderLevel(t *testing.T) {
 			expected: ResultLevelNone,
 		},
 		{
-			desc:     "info should be normalized to note",
+			desc:     "note should be normalized to info",
 			template: render.MustCompile(`{{ .level }}`),
 			data: resultData{
-				"level": "info",
+				"level": "note",
 			},
-			expected: ResultLevelNote,
+			expected: ResultLevelInfo,
 		},
 		{
 			desc:     "warn should be normalized to warning",

--- a/internal/stylist/result_printer.go
+++ b/internal/stylist/result_printer.go
@@ -77,8 +77,8 @@ func (p *TtyPrinter) printLocation(result *Result, formatter *ioutil.Formatter) 
 		severity = formatter.Red(severity) + ": "
 	case ResultLevelWarning:
 		severity = formatter.Yellow(severity) + ": "
-	case ResultLevelNote:
-		severity = formatter.Blue(severity) + ": "
+	case ResultLevelInfo:
+		severity = formatter.Cyan(severity) + ": "
 	case ResultLevelNone:
 		severity = formatter.Gray(severity) + ": "
 	default:

--- a/internal/stylist/result_printer_test.go
+++ b/internal/stylist/result_printer_test.go
@@ -65,7 +65,7 @@ func TestTtyPrinter_Print(t *testing.T) {
 		},
 		{
 			Source: "test-linter",
-			Level:  ResultLevelNote,
+			Level:  ResultLevelInfo,
 			Location: ResultLocation{
 				Path:        "some/path/baz.go",
 				StartLine:   1,
@@ -127,7 +127,7 @@ func TestTtyPrinter_Print(t *testing.T) {
 			expected: []string{
 				"some/path/foo.go:1:0: error: test-linter: no start column. [rule-id1]",
 				"some/path/bar.go:2:10: warning: test-linter: valid start and end column. [rule-id2]",
-				"some/path/baz.go:1:1: note: test-linter: single char indicator. [rule-id3]",
+				"some/path/baz.go:1:1: info: test-linter: single char indicator. [rule-id3]",
 				"some/path/qux.go:1:99: none: test-linter: out of bounds indicator. [rule-id4]",
 			},
 			err: "",
@@ -145,7 +145,7 @@ func TestTtyPrinter_Print(t *testing.T) {
 				"some/path/bar.go:2:10: warning: test-linter: valid start and end column. [rule-id2]",
 				"\tcontext line two",
 				"\t        ^^^^",
-				"some/path/baz.go:1:1: note: test-linter: single char indicator. [rule-id3]",
+				"some/path/baz.go:1:1: info: test-linter: single char indicator. [rule-id3]",
 				"context line three",
 				"^",
 				"some/path/qux.go:1:99: none: test-linter: out of bounds indicator. [rule-id4]",
@@ -166,7 +166,7 @@ func TestTtyPrinter_Print(t *testing.T) {
 					"[rule-id1](https://test-linter.com/rule-id1)",
 				"some/path/bar.go:2:10: warning: test-linter: valid start and end column. " +
 					"[rule-id2](https://test-linter.com/rule-id2)",
-				"some/path/baz.go:1:1: note: test-linter: single char indicator. " +
+				"some/path/baz.go:1:1: info: test-linter: single char indicator. " +
 					"[rule-id3](https://test-linter.com/rule-id3)",
 				"some/path/qux.go:1:99: none: test-linter: out of bounds indicator. " +
 					"[rule-id4](https://test-linter.com/rule-id4)",


### PR DESCRIPTION
Closes #14.

Also:

- Changes `ResultLevelNote` to `ResultLevelInfo` ("note" just didn't feel right).
- Changes "info" color to Cyan in TTY printer.
- Adds completion functions for boolean flags.
