### PR TITLE
feat: add checkstyle as both input and output format

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -20,6 +20,7 @@ ignoreRegExpList:
   - /import \([^)]+\)/g
 words:
   - buildx
+  - checkstyle
   - codecov
   - debugf
   - debugln

--- a/internal/checkstyle/checkstyle.go
+++ b/internal/checkstyle/checkstyle.go
@@ -1,0 +1,35 @@
+package checkstyle
+
+import (
+	"encoding/xml"
+)
+
+// CSResult represents a checkstyle XML result.
+//
+//	<?xml version="1.0" encoding="utf-8"?>
+//	<checkstyle version="4.3">
+//		<file name="filename">
+//			<error line="1" column="3" severity="error" message="msg" source="src" />
+//			<error line="2" column="9" severity="error" message="msg" source="src" />
+//		</file>
+//	</checkstyle>
+type CSResult struct {
+	XMLName xml.Name  `xml:"checkstyle"`
+	Version string    `xml:"version,attr"`
+	Files   []*CSFile `xml:"file,omitempty"`
+}
+
+// CSFile represents a checkstyle XML file element.
+type CSFile struct {
+	Name   string     `xml:"name,attr"`
+	Errors []*CSError `xml:"error"`
+}
+
+// CSError represents a checkstyle XML error element.
+type CSError struct {
+	Line     int    `xml:"line,attr"`
+	Column   int    `xml:"column,attr"`
+	Message  string `xml:"message,attr"`
+	Severity string `xml:"severity,attr,omitempty"`
+	Source   string `xml:"source,attr,omitempty"`
+}

--- a/internal/stylist/enums.go
+++ b/internal/stylist/enums.go
@@ -46,7 +46,7 @@ func CoerceResultLevel(value string) (ResultLevel, error) {
 
 // ResultFormat represents how to format the results.
 //
-// ENUM(sarif, tty).
+// ENUM(checkstyle, sarif, tty).
 type ResultFormat string
 
 // ResultSort represents how to sort the results.

--- a/internal/stylist/enums.go
+++ b/internal/stylist/enums.go
@@ -19,7 +19,7 @@ type OutputType string
 
 // OutputFormat represents how to parse command output.
 //
-// ENUM(diff, json, none, regexp, sarif).
+// ENUM(checkstyle, diff, json, none, regexp, sarif).
 type OutputFormat string
 
 // ResultLevel represents the severity level of the result.

--- a/internal/stylist/enums_enum.go
+++ b/internal/stylist/enums_enum.go
@@ -37,7 +37,8 @@ func (x CommandType) String() string {
 	return string(x)
 }
 
-// String implements the Stringer interface.
+// IsValid provides a quick way to determine if the typed value is
+// part of the allowed enumerated values
 func (x CommandType) IsValid() bool {
 	_, err := ParseCommandType(string(x))
 	return err == nil
@@ -120,7 +121,8 @@ func (x InputType) String() string {
 	return string(x)
 }
 
-// String implements the Stringer interface.
+// IsValid provides a quick way to determine if the typed value is
+// part of the allowed enumerated values
 func (x InputType) IsValid() bool {
 	_, err := ParseInputType(string(x))
 	return err == nil
@@ -205,7 +207,8 @@ func (x LogLevel) String() string {
 	return string(x)
 }
 
-// String implements the Stringer interface.
+// IsValid provides a quick way to determine if the typed value is
+// part of the allowed enumerated values
 func (x LogLevel) IsValid() bool {
 	_, err := ParseLogLevel(string(x))
 	return err == nil
@@ -293,7 +296,8 @@ func (x OutputFormat) String() string {
 	return string(x)
 }
 
-// String implements the Stringer interface.
+// IsValid provides a quick way to determine if the typed value is
+// part of the allowed enumerated values
 func (x OutputFormat) IsValid() bool {
 	_, err := ParseOutputFormat(string(x))
 	return err == nil
@@ -373,7 +377,8 @@ func (x OutputType) String() string {
 	return string(x)
 }
 
-// String implements the Stringer interface.
+// IsValid provides a quick way to determine if the typed value is
+// part of the allowed enumerated values
 func (x OutputType) IsValid() bool {
 	_, err := ParseOutputType(string(x))
 	return err == nil
@@ -425,6 +430,8 @@ func (x *OutputType) Type() string {
 }
 
 const (
+	// ResultFormatCheckstyle is a ResultFormat of type checkstyle.
+	ResultFormatCheckstyle ResultFormat = "checkstyle"
 	// ResultFormatSarif is a ResultFormat of type sarif.
 	ResultFormatSarif ResultFormat = "sarif"
 	// ResultFormatTty is a ResultFormat of type tty.
@@ -434,6 +441,7 @@ const (
 var ErrInvalidResultFormat = fmt.Errorf("not a valid ResultFormat, try [%s]", strings.Join(_ResultFormatNames, ", "))
 
 var _ResultFormatNames = []string{
+	string(ResultFormatCheckstyle),
 	string(ResultFormatSarif),
 	string(ResultFormatTty),
 }
@@ -450,15 +458,17 @@ func (x ResultFormat) String() string {
 	return string(x)
 }
 
-// String implements the Stringer interface.
+// IsValid provides a quick way to determine if the typed value is
+// part of the allowed enumerated values
 func (x ResultFormat) IsValid() bool {
 	_, err := ParseResultFormat(string(x))
 	return err == nil
 }
 
 var _ResultFormatValue = map[string]ResultFormat{
-	"sarif": ResultFormatSarif,
-	"tty":   ResultFormatTty,
+	"checkstyle": ResultFormatCheckstyle,
+	"sarif":      ResultFormatSarif,
+	"tty":        ResultFormatTty,
 }
 
 // ParseResultFormat attempts to convert a string to a ResultFormat.
@@ -545,6 +555,13 @@ func (x ResultLevel) String() string {
 	return fmt.Sprintf("ResultLevel(%d)", x)
 }
 
+// IsValid provides a quick way to determine if the typed value is
+// part of the allowed enumerated values
+func (x ResultLevel) IsValid() bool {
+	_, ok := _ResultLevelMap[x]
+	return ok
+}
+
 var _ResultLevelValue = map[string]ResultLevel{
 	_ResultLevelName[0:4]:   ResultLevelNone,
 	_ResultLevelName[4:8]:   ResultLevelInfo,
@@ -622,7 +639,8 @@ func (x ResultSort) String() string {
 	return string(x)
 }
 
-// String implements the Stringer interface.
+// IsValid provides a quick way to determine if the typed value is
+// part of the allowed enumerated values
 func (x ResultSort) IsValid() bool {
 	_, err := ParseResultSort(string(x))
 	return err == nil

--- a/internal/stylist/enums_enum.go
+++ b/internal/stylist/enums_enum.go
@@ -262,6 +262,8 @@ func (x *LogLevel) Type() string {
 }
 
 const (
+	// OutputFormatCheckstyle is a OutputFormat of type checkstyle.
+	OutputFormatCheckstyle OutputFormat = "checkstyle"
 	// OutputFormatDiff is a OutputFormat of type diff.
 	OutputFormatDiff OutputFormat = "diff"
 	// OutputFormatJson is a OutputFormat of type json.
@@ -277,6 +279,7 @@ const (
 var ErrInvalidOutputFormat = fmt.Errorf("not a valid OutputFormat, try [%s]", strings.Join(_OutputFormatNames, ", "))
 
 var _OutputFormatNames = []string{
+	string(OutputFormatCheckstyle),
 	string(OutputFormatDiff),
 	string(OutputFormatJson),
 	string(OutputFormatNone),
@@ -304,11 +307,12 @@ func (x OutputFormat) IsValid() bool {
 }
 
 var _OutputFormatValue = map[string]OutputFormat{
-	"diff":   OutputFormatDiff,
-	"json":   OutputFormatJson,
-	"none":   OutputFormatNone,
-	"regexp": OutputFormatRegexp,
-	"sarif":  OutputFormatSarif,
+	"checkstyle": OutputFormatCheckstyle,
+	"diff":       OutputFormatDiff,
+	"json":       OutputFormatJson,
+	"none":       OutputFormatNone,
+	"regexp":     OutputFormatRegexp,
+	"sarif":      OutputFormatSarif,
 }
 
 // ParseOutputFormat attempts to convert a string to a OutputFormat.

--- a/internal/stylist/enums_test.go
+++ b/internal/stylist/enums_test.go
@@ -98,8 +98,7 @@ func TestResultLevel(t *testing.T) {
 
 	name := names[0]
 	enum, _ := ParseResultLevel(name)
-	// Pending https://github.com/abice/go-enum/issues/177
-	// require.True(t, enum.IsValid())
+	require.True(t, enum.IsValid())
 	require.Equal(t, enum, enum.Get())
 	require.NoError(t, enum.Set(enum.String()))
 
@@ -112,6 +111,8 @@ func TestResultLevel(t *testing.T) {
 	require.NoError(t, err)
 	err = enum.UnmarshalText([]byte{})
 	require.Error(t, err)
+
+	_ = ResultLevel(99).String()
 }
 
 func TestCoerceResultLevel(t *testing.T) {
@@ -187,6 +188,27 @@ func TestResultFormat(t *testing.T) {
 
 	name := names[0]
 	enum, _ := ParseResultFormat(name)
+	require.True(t, enum.IsValid())
+	require.Equal(t, enum, enum.Get())
+	require.NoError(t, enum.Set(enum.String()))
+
+	enumType := strings.TrimPrefix(fmt.Sprintf("%T", enum), "stylist.")
+	require.Equal(t, enumType, enum.Type())
+
+	marshalled, err := enum.MarshalText()
+	require.NoError(t, err)
+	err = enum.UnmarshalText(marshalled)
+	require.NoError(t, err)
+	err = enum.UnmarshalText([]byte{})
+	require.Error(t, err)
+}
+
+func TestResultSort(t *testing.T) {
+	names := ResultSortNames()
+	require.True(t, len(names) > 0)
+
+	name := names[0]
+	enum, _ := ParseResultSort(name)
 	require.True(t, enum.IsValid())
 	require.Equal(t, enum, enum.Get())
 	require.NoError(t, enum.Set(enum.String()))

--- a/internal/stylist/result_printer_test.go
+++ b/internal/stylist/result_printer_test.go
@@ -1,9 +1,11 @@
 package stylist
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/twelvelabs/termite/ui"
 )
 
@@ -21,6 +23,105 @@ func TestNewResultPrinter(t *testing.T) {
 		config.Output.Format = ResultFormat("unknown")
 		_ = NewResultPrinter(ios, config)
 	})
+}
+
+func TestCheckstylePrinter_Print(t *testing.T) {
+	results := []*Result{
+		{
+			Source: "test-linter",
+			Level:  ResultLevelError,
+			Location: ResultLocation{
+				Path:        "some/path/foo.go",
+				StartLine:   1,
+				StartColumn: 0,
+			},
+			Rule: ResultRule{
+				ID:          "rule-id1",
+				Name:        "rule-name1",
+				Description: "no start column",
+			},
+		},
+		{
+			Source: "test-linter",
+			Level:  ResultLevelWarning,
+			Location: ResultLocation{
+				Path:        "some/path/foo.go",
+				StartLine:   2,
+				StartColumn: 3,
+			},
+			Rule: ResultRule{
+				ID:          "rule-id2",
+				Name:        "rule-name2",
+				Description: "valid start column",
+			},
+		},
+		{
+			Source: "test-linter",
+			Level:  ResultLevelWarning,
+			Location: ResultLocation{
+				Path:        "some/path/bar.go",
+				StartLine:   4,
+				StartColumn: 5,
+			},
+			Rule: ResultRule{
+				ID:          "rule-id2",
+				Name:        "rule-name2",
+				Description: "another valid start column",
+			},
+		},
+	}
+
+	tests := []struct {
+		desc     string
+		results  []*Result
+		expected string
+		err      string
+	}{
+		{
+			desc:     "empty result set should print nothing",
+			results:  []*Result{},
+			expected: `<?xml version="1.0" encoding="UTF-8"?><checkstyle version="4.3"></checkstyle>`,
+		},
+
+		{
+			desc:     "should print a minimal result set when config disabled",
+			results:  results,
+			expected: `<?xml version="1.0" encoding="UTF-8"?><checkstyle version="4.3"><file name="some/path/foo.go"><error line="1" column="0" message="no start column [rule-id1]" severity="error" source="test-linter"></error><error line="2" column="3" message="valid start column [rule-id2]" severity="warning" source="test-linter"></error></file><file name="some/path/bar.go"><error line="4" column="5" message="another valid start column [rule-id2]" severity="warning" source="test-linter"></error></file></checkstyle>`, //nolint: lll
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			app := NewTestApp()
+			printer := &CheckstylePrinter{
+				ios:    app.IO,
+				config: app.Config,
+			}
+			err := printer.Print(tt.results)
+
+			if tt.err == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.err)
+			}
+
+			out := app.IO.Out.String()
+			out = strings.ReplaceAll(out, "\n", "")
+			assert.Equal(t, tt.expected, out)
+		})
+	}
+}
+
+func TestSarifPrinter_Print(t *testing.T) {
+	app := NewTestApp()
+	printer := &SarifPrinter{
+		ios:    app.IO,
+		config: app.Config,
+	}
+	results := []*Result{}
+
+	err := printer.Print(results)
+	assert.NoError(t, err)
 }
 
 func TestTtyPrinter_Print(t *testing.T) {

--- a/internal/stylist/testdata/output/golangci.xml
+++ b/internal/stylist/testdata/output/golangci.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="5.0">
+    <file name="internal/stylist/output_parser.go">
+        <error column="76" line="33" message="Comment should end in a period" severity="error" source="godot"></error>
+        <error column="48" line="57" message="Comment should end in a period" severity="error" source="godot"></error>
+    </file>
+    <file name="internal/stylist/output_parser_test.go">
+        <error column="7" line="35" message="Comment should end in a period" severity="error" source="godot"></error>
+    </file>
+</checkstyle>


### PR DESCRIPTION
- Adds the ability to parse [checkstyle.org](https://checkstyle.org) formatted output in processors.
- Adds the ability to format stylist results as checkstyle XML.
- Adds a few more lines of test coverage in `enums_test.go` and `output_parser_test.go`.

Closes #20 