### PR TITLE
feat: add JSON result format

### DIFF
--- a/internal/stylist/context_line_analyzer.go
+++ b/internal/stylist/context_line_analyzer.go
@@ -1,0 +1,29 @@
+package stylist
+
+import (
+	"strings"
+
+	"github.com/alecthomas/chroma/v2/lexers"
+)
+
+// NewContextLineAnalyzer returns a new ContextLineAnalyzer.
+func NewContextLineAnalyzer() *ContextLineAnalyzer {
+	return &ContextLineAnalyzer{}
+}
+
+// ContextLineAnalyzer analyzes context lines and returns relevant metadata.
+type ContextLineAnalyzer struct {
+}
+
+// DetectLanguage analyzes the given context lines and returns
+// the detected programming language.
+func (s *ContextLineAnalyzer) DetectLanguage(path string, lines []string) string {
+	l := lexers.Match(path)
+	if l == nil {
+		l = lexers.Analyse(strings.Join(lines, "\n")) // cspell:words Analyse
+	}
+	if l == nil {
+		l = lexers.Get("plaintext")
+	}
+	return strings.ToLower(l.Config().Name)
+}

--- a/internal/stylist/context_line_analyzer_test.go
+++ b/internal/stylist/context_line_analyzer_test.go
@@ -1,0 +1,68 @@
+package stylist
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewContextLineAnalyzer(t *testing.T) {
+	require.NotNil(t, NewContextLineAnalyzer())
+}
+
+func TestContextLineAnalyzer_DetectLanguage(t *testing.T) {
+	tests := []struct {
+		desc     string
+		path     string
+		lines    []string
+		expected string
+	}{
+		{
+			desc:     "should default to plaintext when all input values are empty",
+			expected: "plaintext",
+		},
+		{
+			desc:     "[path] should detect golang",
+			path:     "example.go",
+			expected: "go",
+		},
+		{
+			desc:     "[path] should detect javascript",
+			path:     "example.js",
+			expected: "javascript",
+		},
+		{
+			desc:     "[path] should detect python",
+			path:     "example.py",
+			expected: "python",
+		},
+		{
+			desc:     "[path] should fallback to plaintext",
+			path:     "README",
+			expected: "plaintext",
+		},
+		{
+			desc: "[lines] should detect golang",
+			lines: []string{
+				`package stylist`,
+				``,
+				`type Example struct {}`,
+			},
+			expected: "go",
+		},
+		{
+			desc: "[lines] should fallback to plaintext",
+			lines: []string{
+				`no idea what this is`,
+			},
+			expected: "plaintext",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			analyzer := NewContextLineAnalyzer()
+			actual := analyzer.DetectLanguage(tt.path, tt.lines)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/internal/stylist/enums.go
+++ b/internal/stylist/enums.go
@@ -46,7 +46,7 @@ func CoerceResultLevel(value string) (ResultLevel, error) {
 
 // ResultFormat represents how to format the results.
 //
-// ENUM(checkstyle, sarif, tty).
+// ENUM(checkstyle, json, sarif, tty).
 type ResultFormat string
 
 // ResultSort represents how to sort the results.

--- a/internal/stylist/enums_enum.go
+++ b/internal/stylist/enums_enum.go
@@ -436,6 +436,8 @@ func (x *OutputType) Type() string {
 const (
 	// ResultFormatCheckstyle is a ResultFormat of type checkstyle.
 	ResultFormatCheckstyle ResultFormat = "checkstyle"
+	// ResultFormatJson is a ResultFormat of type json.
+	ResultFormatJson ResultFormat = "json"
 	// ResultFormatSarif is a ResultFormat of type sarif.
 	ResultFormatSarif ResultFormat = "sarif"
 	// ResultFormatTty is a ResultFormat of type tty.
@@ -446,6 +448,7 @@ var ErrInvalidResultFormat = fmt.Errorf("not a valid ResultFormat, try [%s]", st
 
 var _ResultFormatNames = []string{
 	string(ResultFormatCheckstyle),
+	string(ResultFormatJson),
 	string(ResultFormatSarif),
 	string(ResultFormatTty),
 }
@@ -471,6 +474,7 @@ func (x ResultFormat) IsValid() bool {
 
 var _ResultFormatValue = map[string]ResultFormat{
 	"checkstyle": ResultFormatCheckstyle,
+	"json":       ResultFormatJson,
 	"sarif":      ResultFormatSarif,
 	"tty":        ResultFormatTty,
 }

--- a/internal/stylist/pipeline.go
+++ b/internal/stylist/pipeline.go
@@ -214,13 +214,19 @@ func SortResults(ctx context.Context, results []*Result) ([]*Result, error) {
 
 func EnsureContextLines(_ context.Context, results []*Result) ([]*Result, error) {
 	loader := NewContextLineLoader()
+	analyzer := NewContextLineAnalyzer()
 	for _, result := range results {
+		path := result.Location.Path
+		lines, err := loader.Load(result.Location)
+		if err != nil {
+			return nil, err
+		}
+
 		if result.ContextLines == nil {
-			lines, err := loader.Load(result.Location)
-			if err != nil {
-				return nil, err
-			}
 			result.ContextLines = lines
+		}
+		if result.ContextLang == "" {
+			result.ContextLang = analyzer.DetectLanguage(path, lines)
 		}
 	}
 	return results, nil

--- a/internal/stylist/result.go
+++ b/internal/stylist/result.go
@@ -6,21 +6,21 @@ import (
 
 // Result describes a single result detected by a processor.
 type Result struct {
-	Source       string
-	Level        ResultLevel
-	Location     ResultLocation
-	Rule         ResultRule
-	ContextLines []string
-	ContextLang  string
+	Source       string         `json:"source"`
+	Level        ResultLevel    `json:"level"`
+	Location     ResultLocation `json:"location"`
+	Rule         ResultRule     `json:"rule"`
+	ContextLines []string       `json:"context_lines"`
+	ContextLang  string         `json:"context_lang"`
 }
 
 // ResultLocation describes the physical location where the result occurred.
 type ResultLocation struct {
-	Path        string
-	StartLine   int
-	StartColumn int
-	EndLine     int
-	EndColumn   int
+	Path        string `json:"path"`
+	StartLine   int    `json:"start_line"`
+	StartColumn int    `json:"start_column"`
+	EndLine     int    `json:"end_line"`
+	EndColumn   int    `json:"end_column"`
 }
 
 // Returns the start and end lines.
@@ -43,10 +43,10 @@ func (r ResultLocation) String() string {
 
 // ResultRule describes the rule that was evaluated to produce the result.
 type ResultRule struct {
-	ID          string
-	Name        string
-	Description string
-	URI         string
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	URI         string `json:"uri"`
 }
 
 // Results is a sortable collection of results.

--- a/internal/stylist/result_printer.go
+++ b/internal/stylist/result_printer.go
@@ -2,6 +2,7 @@ package stylist
 
 import (
 	"bytes"
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"strings"
@@ -27,6 +28,8 @@ func NewResultPrinter(ios *ui.IOStreams, config *Config) ResultPrinter { //nolin
 	switch format {
 	case ResultFormatCheckstyle:
 		return &CheckstylePrinter{ios: ios, config: config}
+	case ResultFormatJson:
+		return &JSONPrinter{ios: ios, config: config}
 	case ResultFormatSarif:
 		return &SarifPrinter{ios: ios, config: config}
 	case ResultFormatTty:
@@ -86,6 +89,27 @@ func (p *CheckstylePrinter) Print(results []*Result) error {
 }
 
 /*
+* JSONPrinter
+**/
+
+// JSONPrinter generates JSON formatted output.
+type JSONPrinter struct {
+	ios    *ui.IOStreams
+	config *Config
+}
+
+// Print writes the JSON formatted results to Stdout.
+func (p *JSONPrinter) Print(results []*Result) error {
+	buf, err := json.Marshal(results)
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprint(p.ios.Out, string(buf)+"\n")
+	return err
+}
+
+/*
 * SarifPrinter
 **/
 
@@ -136,7 +160,6 @@ func (p *TtyPrinter) printLocation(result *Result, formatter *ui.Formatter) {
 	case ResultLevelNone:
 		severity = formatter.Gray(severity) + ": "
 	default:
-		severity = ""
 	}
 
 	source := result.Source

--- a/internal/stylist/result_printer_test.go
+++ b/internal/stylist/result_printer_test.go
@@ -78,13 +78,13 @@ func TestCheckstylePrinter_Print(t *testing.T) {
 		err      string
 	}{
 		{
-			desc:     "empty result set should print nothing",
+			desc:     "empty result set should print an empty checkstyle doc",
 			results:  []*Result{},
 			expected: `<?xml version="1.0" encoding="UTF-8"?><checkstyle version="4.3"></checkstyle>`,
 		},
 
 		{
-			desc:     "should print a minimal result set when config disabled",
+			desc:     "a non empty result set should print checkstyle formatted results",
 			results:  results,
 			expected: `<?xml version="1.0" encoding="UTF-8"?><checkstyle version="4.3"><file name="some/path/foo.go"><error line="1" column="0" message="no start column [rule-id1]" severity="error" source="test-linter"></error><error line="2" column="3" message="valid start column [rule-id2]" severity="warning" source="test-linter"></error></file><file name="some/path/bar.go"><error line="4" column="5" message="another valid start column [rule-id2]" severity="warning" source="test-linter"></error></file></checkstyle>`, //nolint: lll
 		},
@@ -108,6 +108,93 @@ func TestCheckstylePrinter_Print(t *testing.T) {
 			out := app.IO.Out.String()
 			out = strings.ReplaceAll(out, "\n", "")
 			assert.Equal(t, tt.expected, out)
+		})
+	}
+}
+
+func TestJSONPrinter_Print(t *testing.T) {
+	results := []*Result{
+		{
+			Source: "test-linter",
+			Level:  ResultLevelError,
+			Location: ResultLocation{
+				Path:        "some/path/foo.go",
+				StartLine:   1,
+				StartColumn: 0,
+			},
+			Rule: ResultRule{
+				ID:          "rule-id1",
+				Name:        "rule-name1",
+				Description: "no start column",
+			},
+		},
+		{
+			Source: "test-linter",
+			Level:  ResultLevelWarning,
+			Location: ResultLocation{
+				Path:        "some/path/foo.go",
+				StartLine:   2,
+				StartColumn: 3,
+			},
+			Rule: ResultRule{
+				ID:          "rule-id2",
+				Name:        "rule-name2",
+				Description: "valid start column",
+			},
+		},
+		{
+			Source: "test-linter",
+			Level:  ResultLevelWarning,
+			Location: ResultLocation{
+				Path:        "some/path/bar.go",
+				StartLine:   4,
+				StartColumn: 5,
+			},
+			Rule: ResultRule{
+				ID:          "rule-id2",
+				Name:        "rule-name2",
+				Description: "another valid start column",
+			},
+		},
+	}
+
+	tests := []struct {
+		desc     string
+		results  []*Result
+		expected string
+		err      string
+	}{
+		{
+			desc:     "empty result set should print an empty JSON array",
+			results:  []*Result{},
+			expected: `[]`,
+		},
+
+		{
+			desc:     "a non empty result set should print JSON formatted results",
+			results:  results,
+			expected: `[{"source":"test-linter","level":"error","location":{"path":"some/path/foo.go","start_line":1,"start_column":0,"end_line":0,"end_column":0},"rule":{"id":"rule-id1","name":"rule-name1","description":"no start column","uri":""},"context_lines":null,"context_lang":""},{"source":"test-linter","level":"warning","location":{"path":"some/path/foo.go","start_line":2,"start_column":3,"end_line":0,"end_column":0},"rule":{"id":"rule-id2","name":"rule-name2","description":"valid start column","uri":""},"context_lines":null,"context_lang":""},{"source":"test-linter","level":"warning","location":{"path":"some/path/bar.go","start_line":4,"start_column":5,"end_line":0,"end_column":0},"rule":{"id":"rule-id2","name":"rule-name2","description":"another valid start column","uri":""},"context_lines":null,"context_lang":""}]`, //nolint: lll
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			app := NewTestApp()
+			printer := &JSONPrinter{
+				ios:    app.IO,
+				config: app.Config,
+			}
+			err := printer.Print(tt.results)
+
+			if tt.err == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.err)
+			}
+
+			out := app.IO.Out.String()
+			out = strings.ReplaceAll(out, "\n", "")
+			require.Equal(t, tt.expected, out)
 		})
 	}
 }


### PR DESCRIPTION
- Adds ability to render stylist results in JSON format.

```shell
[sbaney@helios:~/src/twelvelabs/stylist] $ stylist check --format=json | jq
Error: 1 issue(s)
[
  {
    "source": "golangci-lint",
    "level": "error",
    "location": {
      "path": "internal/stylist/result_printer.go",
      "start_line": 101,
      "start_column": 53,
      "end_line": 0,
      "end_column": 0
    },
    "rule": {
      "id": "godot",
      "name": "godot",
      "description": "Comment should end in a period",
      "uri": "https://golangci-lint.run/usage/linters/#godot"
    },
    "context_lines": [
      "// Print writes the JSON formatted results to Stdout"
    ],
    "context_lang": "go"
  }
]
```

- Refactors pipeline logic to ensure each result has `ContextLang` set regardless of result format. Previously we were only detecting the language when using the `TtyPrinter`.

Closes #25 

