### PR TITLE
chore: refactor pipelines to be goroutine-safe

### DIFF
--- a/internal/cmd/files.go
+++ b/internal/cmd/files.go
@@ -60,20 +60,15 @@ func (a *FilesAction) Run(ctx context.Context) error {
 	}
 
 	pipeline := stylist.NewPipeline(processors, excludes)
-	err = pipeline.Index(ctx, a.pathSpecs)
+	matches, err := pipeline.Match(ctx, a.pathSpecs)
 	if err != nil {
 		return err
 	}
 
-	for _, processor := range processors {
-		fmt.Printf("Processor: %s\n", processor.Name)
-		paths := processor.Paths()
-		if len(paths) == 0 {
-			fmt.Printf(" [no matching files]\n")
-		} else {
-			for _, path := range processor.Paths() {
-				fmt.Printf(" - %s\n", path)
-			}
+	for _, match := range matches {
+		fmt.Printf("Processor: %s\n", match.Processor.Name)
+		for _, path := range match.Paths {
+			fmt.Printf(" - %s\n", path)
 		}
 		fmt.Printf("\n")
 	}

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -72,9 +72,14 @@ func (a *InitAction) Run(ctx context.Context) error {
 	presets := store.All()
 	excludes := config.Excludes
 	pipeline := stylist.NewPipeline(presets, excludes)
-	processors, err := pipeline.Match(ctx, []string{"."})
+	matches, err := pipeline.Match(ctx, []string{"."})
 	if err != nil {
 		return err
+	}
+
+	processors := []*stylist.Processor{}
+	for _, match := range matches {
+		processors = append(processors, match.Processor)
 	}
 
 	// Generate a new config file containing all matching presets.

--- a/internal/stylist/pipeline_test.go
+++ b/internal/stylist/pipeline_test.go
@@ -142,13 +142,13 @@ func TestPipeline_Check(t *testing.T) {
 	}
 }
 
-func TestPipeline_Index(t *testing.T) {
+func TestPipeline_Match(t *testing.T) {
 	tests := []struct {
 		desc       string
 		processors []*Processor
 		excludes   []string
 		pathSpecs  []string
-		expectFunc func(t *testing.T, pipeline *Pipeline)
+		expectFunc func(t *testing.T, matches []PipelineMatch)
 		err        string
 	}{
 		{
@@ -178,10 +178,10 @@ func TestPipeline_Index(t *testing.T) {
 			pathSpecs: []string{
 				"testdata/txt",
 			},
-			expectFunc: func(t *testing.T, pipeline *Pipeline) {
+			expectFunc: func(t *testing.T, matches []PipelineMatch) {
 				t.Helper()
 
-				p1 := pipeline.processors[0]
+				assert.Len(t, matches, 2)
 				assert.ElementsMatch(t, []string{
 					"testdata/txt/001/011/111/aaa.txt",
 					"testdata/txt/001/011/aaa.txt",
@@ -190,9 +190,8 @@ func TestPipeline_Index(t *testing.T) {
 					"testdata/txt/003/033/aaa.txt",
 					"testdata/txt/003/aaa.txt",
 					"testdata/txt/aaa.txt",
-				}, p1.Paths())
+				}, matches[0].Paths)
 
-				p2 := pipeline.processors[1]
 				assert.ElementsMatch(t, []string{
 					"testdata/txt/001/011/111/aaa.txt",
 					"testdata/txt/001/011/aaa.txt",
@@ -201,7 +200,7 @@ func TestPipeline_Index(t *testing.T) {
 					"testdata/txt/002/022/aaa.txt",
 					"testdata/txt/002/aaa.txt",
 					"testdata/txt/aaa.txt",
-				}, p2.Paths())
+				}, matches[1].Paths)
 			},
 		},
 	}
@@ -212,7 +211,7 @@ func TestPipeline_Index(t *testing.T) {
 			ctx := app.InitContext(context.Background())
 
 			pipeline := NewPipeline(tt.processors, tt.excludes)
-			err := pipeline.Index(ctx, tt.pathSpecs)
+			matches, err := pipeline.Match(ctx, tt.pathSpecs)
 
 			if tt.err == "" {
 				assert.NoError(t, err)
@@ -221,7 +220,7 @@ func TestPipeline_Index(t *testing.T) {
 			}
 
 			if tt.expectFunc != nil {
-				tt.expectFunc(t, pipeline)
+				tt.expectFunc(t, matches)
 			}
 		})
 	}

--- a/internal/stylist/processor.go
+++ b/internal/stylist/processor.go
@@ -17,12 +17,12 @@ type Processor struct {
 	Excludes     []string `yaml:"excludes,omitempty"`
 	CheckCommand *Command `yaml:"check,omitempty"`
 	FixCommand   *Command `yaml:"fix,omitempty"`
-
-	paths []string
 }
 
-// Execute runs the given command for the current set of paths.
-func (p *Processor) Execute(ctx context.Context, ct CommandType) ([]*Result, error) {
+// Execute runs the given command for paths.
+func (p *Processor) Execute(
+	ctx context.Context, ct CommandType, paths []string,
+) ([]*Result, error) {
 	// Resolve the command to execute.
 	var cmd *Command
 	switch ct {
@@ -30,8 +30,6 @@ func (p *Processor) Execute(ctx context.Context, ct CommandType) ([]*Result, err
 		cmd = p.CheckCommand
 	case CommandTypeFix:
 		cmd = p.FixCommand
-	default:
-		panic(fmt.Sprintf("unknown command type '%s'", ct.String()))
 	}
 
 	if cmd == nil {
@@ -40,7 +38,7 @@ func (p *Processor) Execute(ctx context.Context, ct CommandType) ([]*Result, err
 	}
 
 	// Delegate to the command.
-	return cmd.Execute(ctx, p.Name, p.Paths())
+	return cmd.Execute(ctx, p.Name, paths)
 }
 
 // Merge merges the receiver and arguments and returns a new processor
@@ -52,11 +50,6 @@ func (p *Processor) Merge(others ...*Processor) *Processor {
 		_ = mergo.Merge(dst, other, mergo.WithOverride)
 	}
 	return dst
-}
-
-// Paths returns all paths matched by the processor.
-func (p *Processor) Paths() []string {
-	return p.paths
 }
 
 // ProcessorFilter filters processors by name and/or tag.


### PR DESCRIPTION
Refactors the `Pipeline` methods so they can safely be used in coroutines.

- Removes the `paths` slice from `Processor` to make it immutable. Needed because we pass pointers to the processors around everywhere.
- Merges `Pipeline.Index` into `Pipeline.Match`.
- Updates `Pipeline.Match` to return a collection of match responses, each containing the matched processor and paths.
